### PR TITLE
Geobias toggle

### DIFF
--- a/css/demo.css
+++ b/css/demo.css
@@ -110,6 +110,7 @@ ul.results li a {
   position: absolute;
   top: 10px;
   right: 25px;
+  text-transform: uppercase;
 }
 
 a {

--- a/css/demo.css
+++ b/css/demo.css
@@ -35,6 +35,22 @@ body {
   -webkit-transition: none !important;
 }
 
+.aside .fa-location-arrow {
+  position: absolute;
+  top: 12px;
+  right: 5px;
+  font-size: 20px;
+  color: lightgray;
+}
+
+.aside.geobias-on .fa-location-arrow {
+  color:#428bca;
+}
+
+.aside.geobias-off .fa-location-arrow {
+  color:lightgray;
+}
+
 input[type="text"] {
   padding: 10px;
   border: solid 1px #dcdcdc;
@@ -93,7 +109,7 @@ ul.results li a {
 .label-searchType {
   position: absolute;
   top: 10px;
-  right: 5px;
+  right: 25px;
 }
 
 a {

--- a/index.html
+++ b/index.html
@@ -33,7 +33,10 @@
         <form role="search">
           <div class="input">
             <input type="text" data-ng-model="search" class="form-control" ng-focus="onFocus($event)" ng-blur="onBlur($event)" ng-keydown="keyPressed($event)" placeholder="Search" />
-            <div class="aside">
+            <div class="aside geobias-{{geobias}}">
+              <a data-ng-click="switchGeobias(geobias)">
+                <span class="fa fa-location-arrow"></span>
+              </a>
               <a data-ng-click="switchType(searchType)">
                 <span class="label label-default label-searchType">{{searchType}}</span>
               </a>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         <ul id="suggestresults" class="results">
           <li data-ng-repeat="result in suggestresults">
             <a data-ng-click="selectResult(result, true)">
-              <i class="glyphicon glyphicon-{{result.icon}}"></i>
+              <i title="{{result.type}}" class="glyphicon glyphicon-{{result.icon}}"></i>
               <span data-ng-bind-html="result.htmltext"></span>
               <div class="aside">
                 <em class="label label-info">{{result.distance}}km</em>
@@ -59,7 +59,7 @@
         <ul id="searchresults" class="results">
           <li data-ng-repeat="result in searchresults">
             <a data-ng-click="selectResult(result)">
-              <i class="glyphicon glyphicon-{{result.icon}}"></i>
+              <i title="{{result.type}}" class="glyphicon glyphicon-{{result.icon}}"></i>
               <span data-ng-bind-html="result.htmltext"></span>
               <div class="aside">
                 <em class="label label-info">{{result.distance}}km</em>

--- a/js/demo.js
+++ b/js/demo.js
@@ -199,11 +199,11 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
   $scope.searchresults = [];
   $scope.suggestresults = [];
   $scope.geobias = 'on';
-  $scope.searchType = 'FINE';
+  $scope.searchType = 'fine';
   $scope.api_url = '//pelias.mapzen.com';
 
   $scope.switchType = function(type) {
-    $scope.searchType = type === 'FINE' ? 'COARSE' : 'FINE';
+    $scope.searchType = type === 'fine' ? 'coarse' : 'fine';
     $rootScope.$emit( 'hideall' );
     $scope.fullTextSearch();
   };
@@ -256,7 +256,7 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
       return;
     }
 
-    var url = $scope.searchType === 'FINE' ? '/suggest' : '/suggest/coarse';
+    var url = $scope.searchType.toLowerCase() === 'fine' ? '/suggest' : '/suggest/coarse';
     getResults(url, 'suggestresults');
   }
 
@@ -268,7 +268,7 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
     }
     $rootScope.$emit('fullTextSearch', $scope.search, $scope.searchType, $scope.geobias);
 
-    var url = $scope.searchType === 'FINE' ? '/search' : '/search/coarse';
+    var url = $scope.searchType.toLowerCase() === 'fine' ? '/search' : '/search/coarse';
     getResults(url, 'searchresults');
   }
 

--- a/js/demo.js
+++ b/js/demo.js
@@ -73,12 +73,12 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
     remove_markers();
   });
 
-  $rootScope.$on( 'fullTextSearch', function( ev, text, searchType, hb ){
+  $rootScope.$on( 'fullTextSearch', function( ev, text, searchType, geoBias ){
     $(document).trigger({
       'type': "pelias:fullTextSearch",
       'text' : text,
       'searchType' : searchType,
-      'geoBias': hb
+      'geoBias': geoBias
     });
   });
 

--- a/js/demo.js
+++ b/js/demo.js
@@ -73,11 +73,12 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
     remove_markers();
   });
 
-  $rootScope.$on( 'fullTextSearch', function( ev, text, searchType ){
+  $rootScope.$on( 'fullTextSearch', function( ev, text, searchType, hb ){
     $(document).trigger({
       'type': "pelias:fullTextSearch",
       'text' : text,
-      'searchType' : searchType
+      'searchType' : searchType,
+      'geoBias': hb
     });
   });
 
@@ -148,25 +149,30 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
   };
 
   var getResults = function(url, resultkey) {
-    var bounds = map.getBounds();
-    var bbox = [];
-    bbox.push(bounds._northEast.lat);
-    bbox.push(bounds._northEast.lng);
-    bbox.push(bounds._southWest.lat);
-    bbox.push(bounds._southWest.lng);
+    var params = {
+      input: $scope.search,
+      // datasets: $scope.queryDatasets.join(','),
+      size: 10
+    }
+
+    if ($scope.geobias === 'on') {
+      var bounds = map.getBounds();
+      var bbox = [];
+      bbox.push(bounds._northEast.lat);
+      bbox.push(bounds._northEast.lng);
+      bbox.push(bounds._southWest.lat);
+      bbox.push(bounds._southWest.lng);
+
+      params.lat = $rootScope.geobase ? $rootScope.geobase.lat : 0;
+      params.lon = $rootScope.geobase ? $rootScope.geobase.lon : 0;
+      params.zoom= $rootScope.geobase ? $rootScope.geobase.zoom : 12;
+      params.bbox= bbox.length === 4  ? bbox.join(',') : '';
+    }
 
     $http({
       url: $scope.api_url+url,
       method: 'GET',
-      params: {
-        input: $scope.search,
-        // datasets: $scope.queryDatasets.join(','),
-        lat: $rootScope.geobase ? $rootScope.geobase.lat : 0,
-        lon: $rootScope.geobase ? $rootScope.geobase.lon : 0,
-        zoom:$rootScope.geobase ? $rootScope.geobase.zoom : 12,
-        bbox:bbox.length === 4  ? bbox.join(',') : '',
-        size: 10
-      },
+      params: params,
       headers: { 'Accept': 'application/json' }
     }).success(function (data, status, headers, config) {
       if( data ){
@@ -192,11 +198,18 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
   $scope.search = '';
   $scope.searchresults = [];
   $scope.suggestresults = [];
+  $scope.geobias = 'on';
   $scope.searchType = 'FINE';
   $scope.api_url = '//pelias.mapzen.com';
 
   $scope.switchType = function(type) {
     $scope.searchType = type === 'FINE' ? 'COARSE' : 'FINE';
+    $rootScope.$emit( 'hideall' );
+    $scope.fullTextSearch();
+  };
+
+  $scope.switchGeobias = function(geobias) {
+    $scope.geobias = geobias === 'on' ? 'off' : 'on';
     $rootScope.$emit( 'hideall' );
     $scope.fullTextSearch();
   };
@@ -253,7 +266,7 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
       $rootScope.$emit( 'hideall' );
       return;
     }
-    $rootScope.$emit('fullTextSearch', $scope.search, $scope.searchType);
+    $rootScope.$emit('fullTextSearch', $scope.search, $scope.searchType, $scope.geobias);
 
     var url = $scope.searchType === 'FINE' ? '/search' : '/search/coarse';
     getResults(url, 'searchresults');
@@ -272,6 +285,11 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
   var hash_search_type  = hash_params ? hash_params.t : false;
   if (hash_search_type){
     $scope.searchType = hash_search_type;
+    $scope.keyPressed({ 'which': 13});
+  }
+  var hash_geobias  = hash_params ? hash_params.gb : false;
+  if (hash_geobias){
+    $scope.geobias = hash_geobias;
     $scope.keyPressed({ 'which': 13});
   }
 

--- a/js/demo.js
+++ b/js/demo.js
@@ -183,6 +183,7 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
         $scope[resultkey] = data.features.map( function( res ){
           res.htmltext = $sce.trustAsHtml(highlight( res.properties.text, $scope.search ));
           res.icon = icon( res.properties.type || 'search' );
+          res.type = res.properties.type;
           res.distance = computeDistance(res.geometry.coordinates);
           return res;
         });

--- a/js/leaflet-hash.js
+++ b/js/leaflet-hash.js
@@ -57,7 +57,7 @@
 			} else {
 				var query = hash_obj.q ? hash_obj.q : null;
 				var searchType = hash_obj.t ? hash_obj.t : null;
-				var geoBias = hash_obj.hb ? hash_obj.hb : null;
+				var geoBias = hash_obj.gb ? hash_obj.gb : null;
 				var return_obj = {
 					center: new L.LatLng(lat, lon),
 					zoom: zoom
@@ -74,7 +74,7 @@
 				}
 				if ( geoBias && this.lastGeoBias != geoBias ) {
 					this.lastGeoBias = geoBias;
-					return_obj['hb'] = geoBias;
+					return_obj['gb'] = geoBias;
 				}
 				return return_obj;
 			}
@@ -97,7 +97,7 @@
 
 		var query = this.lastSearchQuery ? "&q=" + this.lastSearchQuery : "";
 		var searchType = this.lastSearchType ? "&t=" + this.lastSearchType : "";
-		var geoBias = this.lastGeoBias ? "&hb=" + this.lastGeoBias : "";
+		var geoBias = this.lastGeoBias ? "&gb=" + this.lastGeoBias : "";
 		return loc + query + searchType + geoBias;
 	},
 

--- a/js/leaflet-hash.js
+++ b/js/leaflet-hash.js
@@ -57,6 +57,7 @@
 			} else {
 				var query = hash_obj.q ? hash_obj.q : null;
 				var searchType = hash_obj.t ? hash_obj.t : null;
+				var geoBias = hash_obj.hb ? hash_obj.hb : null;
 				var return_obj = {
 					center: new L.LatLng(lat, lon),
 					zoom: zoom
@@ -70,6 +71,10 @@
 				if ( searchType && this.lastSearchType != searchType ) {
 					this.lastSearchType = searchType;
 					return_obj['t'] = searchType;
+				}
+				if ( geoBias && this.lastGeoBias != geoBias ) {
+					this.lastGeoBias = geoBias;
+					return_obj['hb'] = geoBias;
 				}
 				return return_obj;
 			}
@@ -92,7 +97,8 @@
 
 		var query = this.lastSearchQuery ? "&q=" + this.lastSearchQuery : "";
 		var searchType = this.lastSearchType ? "&t=" + this.lastSearchType : "";
-		return loc + query + searchType;
+		var geoBias = this.lastGeoBias ? "&hb=" + this.lastGeoBias : "";
+		return loc + query + searchType + geoBias;
 	},
 
 	L.Hash.prototype = {
@@ -100,6 +106,7 @@
 		lastHash: null,
 		lastSearchQuery: null,
 		lastSearchType: null,
+		lastGeoBias: null,
 
 		parseHash: L.Hash.parseHash,
 		formatHash: L.Hash.formatHash,
@@ -113,6 +120,7 @@
 			this.lastHash = null;
 			this.lastSearchQuery = null;
 			this.lastSearchType = null;
+			this.lastGeoBias = null;
 			this.onHashChange();
 
 			if (!this.isListening) {
@@ -194,6 +202,10 @@
 				}
 				if (that.lastSearchType != e.searchType) {
 					that.lastSearchType  = e.searchType;
+					that.onMapMove();
+				}
+				if (that.lastGeoBias != e.geoBias) {
+					that.lastGeoBias  = e.geoBias;
 					that.onMapMove();
 				}
 			});


### PR DESCRIPTION
keeping demo up to date with the ever evolving API. This update takes care of demo-ing toggling between sending geobias (lat/lon) to pelias API and turning it off. 

Click on the location marker in the text box until its grey in color to turn off geobias. If its blue in color, that means loc is turned on and search will be done within the bbox of the viewport and lat/lon will be sent to the API call. 

Hovering on the glypicons in the results drop down will inform the user of the type of result/node (i.e. if its admin0, admin1, neighborhood, osmnode etc)