### PR TITLE
fixed outdated url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 demo
 ====
 
-This is a simple angular app that uses mapzen's pelias api (https://pelias.mapzen.com) to demonstrate the following endpoints.
+This is a simple angular app that uses mapzen's pelias api (https://mapzen.com/pelias) to demonstrate the following endpoints.
 
 * /suggest
 * /search


### PR DESCRIPTION
I just noticed that there seems to be a broken link to the demo app. Maybe you could check.