### PR TITLE
remove map bounds

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -22,6 +22,7 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
   var map = L.map('map', {
       zoom: $rootScope.geobase.zoom,
       zoomControl: false,
+      worldCopyJump: true,
       center: [$rootScope.geobase.lat, $rootScope.geobase.lon]
   });
 

--- a/js/demo.js
+++ b/js/demo.js
@@ -22,8 +22,7 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
   var map = L.map('map', {
       zoom: $rootScope.geobase.zoom,
       zoomControl: false,
-      center: [$rootScope.geobase.lat, $rootScope.geobase.lon],
-      maxBounds: L.latLngBounds(L.latLng(-80, -180), L.latLng(82, 180))
+      center: [$rootScope.geobase.lat, $rootScope.geobase.lon]
   });
 
   if(!L.Hash.parseHash(location.hash) && navigator.geolocation){
@@ -42,8 +41,7 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
   L.tileLayer('//{s}.tiles.mapbox.com/v3/randyme.i0568680/{z}/{x}/{y}.png', {
       attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://www.openstreetmap.org/copyright">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
       maxZoom: 18,
-      minZoom: 3,
-      noWrap: true
+      minZoom: 3
   }).addTo(map);
   new L.Control.Zoom({ position: 'topright' }).addTo(map);
   L.control.locate({ position: 'topright', keepCurrentZoomLevel: true }).addTo(map);

--- a/js/demo.js
+++ b/js/demo.js
@@ -152,9 +152,10 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
       headers: { 'Accept': 'application/json' }
     }).success(function (data, status, headers, config) {
       if (data) {
-        var geo = data.features[0].geometry.coordinates;
+        var geo = data.features[0].geometry.coordinates.reverse();
         var txt = data.features[0].properties.text;
-        $rootScope.$emit( 'map.dropMarker', geo.reverse(), txt, 'star');
+        $rootScope.$emit( 'map.dropMarker', geo, txt, 'star');
+        $rootScope.$emit( 'map.setView', geo, $rootScope.geobase.zoom );
       } else { }
     })
   };


### PR DESCRIPTION
Remove all of the configuration options that bounded the scrollable map area, since they were put in place to prevent out-of-bounds longitude parameters from triggering API parameter errors and that's no longer an issue with pelias/api#121 .

fixes pelias/api#56
