### PR TITLE
Debounce input events to once per 100ms

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       <section id="searchbar" data-ng-controller="SearchController">
         <form role="search">
           <div class="input">
-            <input type="text" data-ng-model="search" class="form-control" ng-focus="onFocus($event)" ng-blur="onBlur($event)" ng-keydown="keyPressed($event)" placeholder="Search" />
+            <input type="text" data-ng-model="search" class="form-control" ng-focus="onFocus($event)" ng-blur="onBlur($event)" ng-keydown="keyPressed($event)" ng-model-options="{ debounce: 100 }" placeholder="Search" />
             <div class="aside geobias-{{geobias}}">
               <a data-ng-click="switchGeobias(geobias)" data-toggle="tooltip" title="click to toggle between sending lat-lon, bbox and nothing. Right now you are sending {{geobiasInfo}}.">
                 <span class="fa geobias-class {{geobiasClass}}"></span>


### PR DESCRIPTION
This drastically reduces the number of requests sent to the backend
when typing quickly. Individual requests return with more than
acceptable performance (~150ms), but if too many are sent too quickly,
they tend to pile up to almost 5000ms!

The tradeoff here is a slightly increased delay for autocomplete. I
tried 500ms down to 50ms and this seems like a good middle ground.

Here's a screenshot of the request panel for a non-debounced session where I type my 17 character long home street address as quickly as possible. Notice that the requests start out fast but quickly pile up and even start to fail.
![non-debounced](https://cloud.githubusercontent.com/assets/111716/8660683/708311ce-2980-11e5-87ff-fc2086e07cf3.png)

And here's the same exact typing done with 100ms debounce. Note there are only 3 queries and they all return really fast.
![debounced](https://cloud.githubusercontent.com/assets/111716/8660713/96116c6a-2980-11e5-8942-81790d35e9a4.png)
